### PR TITLE
Add Missing GitHub Urls

### DIFF
--- a/advocates/barnam-bora.yml
+++ b/advocates/barnam-bora.yml
@@ -21,6 +21,8 @@ connect:
     url: https://linkedin.com/in/barnam
   - title: Twitter
     url: https://twitter.com/barnambora
+  - title: GitHub
+    url: https://github.com/barnam-bora
 location:
   display: Melbourne, Australia
   lat: -37.840935

--- a/advocates/burke-holland.yml
+++ b/advocates/burke-holland.yml
@@ -44,6 +44,9 @@ connect:
     url: https://www.instagram.com/burkeholland
   - title: LinkedIn
     url: https://linkedin.com/in/burkeholland
+  - title: GitHub
+    url: https://github.com/burkeholland
+
 location:
   display: Franklin, TN, USA
   lat: 35.925064

--- a/advocates/chris-nwamba.yml
+++ b/advocates/chris-nwamba.yml
@@ -24,6 +24,8 @@ connect:
     url: https://www.codebeast.dev/articles
   - title: LinkedIn
     url: https://www.linkedin.com/in/chris-nwamba-032b04b2/
+  - title: GitHub
+    url: https://github.com/christiannwamba
 location:
   display: Lagos, Nigeria
   lat: 6.524379

--- a/advocates/christina-warren.yml
+++ b/advocates/christina-warren.yml
@@ -28,6 +28,8 @@ connect:
     url: https://facebook.com/christina.warren
   - title: LinkedIn
     url: https://linkedin.com/in/filmgirl/
+  - title: GitHub
+    url: https://github.com/filmgirl
 location:
   display: Redmond, Washington, United States
   lat: 47.679194

--- a/advocates/david-blank-edelman.yml
+++ b/advocates/david-blank-edelman.yml
@@ -25,6 +25,8 @@ connect:
     url: https://twitter.com/otterbook
   - title: LinkedIn
     url: https://linkedin.com/in/dnblankedelman
+  - title: GitHub
+    url: https://github.com/dnblankedelman
 location:
   display: Somerville, Massachusetts, United States
   lat: 42.3875968

--- a/advocates/gustavo-cordido.yml
+++ b/advocates/gustavo-cordido.yml
@@ -28,6 +28,8 @@ connect:
     url: https://twitter.com/gcordidoa
   - title: LinkedIn
     url: https://www.linkedin.com/in/gcordidoa
+  - title: GitHub
+    url: https://github.com/gcordido
 
 location:
   display: Miramar, FL

--- a/advocates/lims-wang.yml
+++ b/advocates/lims-wang.yml
@@ -21,6 +21,8 @@ image:
 connect: 
   - title: LinkedIn
     url: https://www.linkedin.com/in/lims-wang-264bb378
+  - title: GitHub
+    url: https://github.com/limswang
 location:
   display: Beijing, China
   lat: 39.9799903172

--- a/advocates/pierre-roman.yml
+++ b/advocates/pierre-roman.yml
@@ -27,6 +27,8 @@ connect:
     url: https://itopstalk.com/
   - title: LinkedIn
     url: https://www.linkedin.com/in/pierreroman/
+  - title: GitHub
+    url: https://github.com/pierreroman
 
 location: 
   display: Ottawa, Ontario, Canada

--- a/advocates/ruth-yakubu.yml
+++ b/advocates/ruth-yakubu.yml
@@ -29,6 +29,8 @@ connect:
     url: https://twitter.com/ruthieyakubu
   - title: LinkedIn
     url: https://linkedin.com/in/ruthyakubu
+  - title: GitHub
+    url: https://github.com/ruyakubu
 location:
   display: New York, New York, United States
   lat: 40.770425

--- a/advocates/thomas-lewis.yml
+++ b/advocates/thomas-lewis.yml
@@ -26,6 +26,8 @@ image:
 connect:
   - title: Twitter
     url: https://twitter.com/tommylee
+  - title: GitHub
+    url: https://github.com/tholewis
 
 location:
   display: Seattle, WA

--- a/advocates/todd-anglin.yml
+++ b/advocates/todd-anglin.yml
@@ -26,13 +26,20 @@ remarks: |
   * [Videos on Vimeo] (https://vimeo.com/toddanglin)
 
 tagline: Web / Mobile Development
+
 image:
   alt: "Todd Anglin Cloud Advocate"
   src: media/profiles/todd-anglin.png
-twitter: https://twitter.com/toddanglin
-github: https://github.com/toddanglin
-stackoverflow: https://stackoverflow.com/users/54305/todd
-linkedin: https://linkedin.com/in/toddanglin
+
+connect:
+  - title: Twitter
+    url: https://twitter.com/toddanglin
+  - title: GitHub
+    url: https://github.com/toddanglin
+  - title: StackOverflow 
+    url: https://stackoverflow.com/users/54305/todd
+  - title: LinkedIn
+    url: https://linkedin.com/in/toddanglin
 #twitch: https://www.twitch.tv/toddanglin
 location:
   display: The Woodlands, Texas, United States


### PR DESCRIPTION
Adds GitHub URLs for the following advocates:
- Barnam Bora
- Burke Holland
- Chris Nwamba
- Christina Warren
- David Blank-Edelman
- Gustavo Cordido
- Lims Wang
- Pierre Roman
- Ruth Yakubu
- Thomas Lewis
- Todd Anglin