### PR TITLE
Remove Twitter + LinkedIn Validation Requirements

### DIFF
--- a/validation/AdvocateValidation.csproj
+++ b/validation/AdvocateValidation.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="9.1.0" />
+    <PackageReference Include="YamlDotNet" Version="9.1.4" />
   </ItemGroup>
 
 </Project>

--- a/validation/Program.cs
+++ b/validation/Program.cs
@@ -20,10 +20,9 @@ namespace AdvocateValidation
 
         readonly static IDeserializer _yamlDeserializer = new DeserializerBuilder().Build();
 
-        static async Task Main(string[] args)
+        static async Task Main()
         {
             const string gitHub = "GitHub";
-            const string linkedIn = "LinkedIn";
 
             var advocateList = new List<CloudAdvocateYamlModel>();
 
@@ -38,10 +37,8 @@ namespace AdvocateValidation
                     throw new Exception($"Missing Team: {filePath}");
 
                 var gitHubUri = advocate.Connect.FirstOrDefault(x => x.Title.Equals(gitHub, StringComparison.OrdinalIgnoreCase))?.Url;
-                var linkedInUri = advocate.Connect.FirstOrDefault(x => x.Title.Equals(linkedIn, StringComparison.OrdinalIgnoreCase))?.Url;
 
                 EnsureValidUri(filePath, gitHubUri, gitHub);
-                EnsureValidUri(filePath, linkedInUri, linkedIn);
 
                 EnsureValidImage(filePath, advocate.Image);
 
@@ -53,6 +50,8 @@ namespace AdvocateValidation
             {
                 throw new Exception($"Duplicate Alias Found; ms.author: {duplicateAlias}");
             }
+
+            Console.WriteLine("Validation Completed Successfully");
         }
 
         static async IAsyncEnumerable<(string filePath, CloudAdvocateYamlModel advocate)> GetAdvocateYmlFiles(IEnumerable<string> files)

--- a/validation/Program.cs
+++ b/validation/Program.cs
@@ -23,7 +23,6 @@ namespace AdvocateValidation
         static async Task Main(string[] args)
         {
             const string gitHub = "GitHub";
-            const string twitter = "Twitter";
             const string linkedIn = "LinkedIn";
 
             var advocateList = new List<CloudAdvocateYamlModel>();
@@ -39,11 +38,9 @@ namespace AdvocateValidation
                     throw new Exception($"Missing Team: {filePath}");
 
                 var gitHubUri = advocate.Connect.FirstOrDefault(x => x.Title.Equals(gitHub, StringComparison.OrdinalIgnoreCase))?.Url;
-                var twitterUri = advocate.Connect.FirstOrDefault(x => x.Title.Equals(twitter, StringComparison.OrdinalIgnoreCase))?.Url;
                 var linkedInUri = advocate.Connect.FirstOrDefault(x => x.Title.Equals(linkedIn, StringComparison.OrdinalIgnoreCase))?.Url;
 
                 EnsureValidUri(filePath, gitHubUri, gitHub);
-                EnsureValidUri(filePath, twitterUri, twitter);
                 EnsureValidUri(filePath, linkedInUri, linkedIn);
 
                 EnsureValidImage(filePath, advocate.Image);


### PR DESCRIPTION
This PR allows for Cloud Advocates to omit their Twitter and LinkedIn information.

The Updated Validation Rules are as follows:
- Microsoft Alias
- Microsoft Team
- GitHub Url
- Square Profile Image (height & width are equal)