### PR TITLE
updating the triggers

### DIFF
--- a/.github/workflows/VerifyAdvocateYAML.yml
+++ b/.github/workflows/VerifyAdvocateYAML.yml
@@ -1,10 +1,13 @@
-# This is a basic workflow to help you get started with Actions
-
-name: CI
+name: Advocate Schema Validation
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
-on: [push, pull_request]
+on: 
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [master, live]
+    paths: 
+      - 'advocates/**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Merging from master causes the advocate validation workflow to be triggered twice due to it being a Merge Commit. It causes a push on the live branch and an opened pull request.

keeping @brminnick in the loop just in case.