### PR TITLE
Add spaces around slashes in Julia Muiruri's tagline

### DIFF
--- a/advocates/julia-muiruri.yml
+++ b/advocates/julia-muiruri.yml
@@ -16,7 +16,7 @@ remarks: |
   - VS Code integration with Microsoft Azure
   - GitHub
 
-tagline: Students/Educators/VS Code
+tagline: Students / Educators / VS Code
 image:
   alt: "Julia Muiruri Cloud Advocate"
   src: media/profiles/julia-muiruri.jpg


### PR DESCRIPTION
Howdy! I represent accessibility efforts for Microsoft Learn. We got a bug concerning text spilling out of the box for Julia's tagline, and it's most easily fixed by adding spaces around the slashes. This also aligns Julia's tagline with all of the other taglines that include slashes.

Please let me know if you have any questions or concerns!

## Validation

1. Open [preview page for Cloud Advocates](https://review.developer.microsoft.com/en-us/advocates/?branch=pr-en-us-950), and scroll down to Julia's card.
2. Resize the browser or zoom in/out. **Julia's tagline should never overflow the card.**